### PR TITLE
Demonstrate issue with pure-batchid approach to queries

### DIFF
--- a/external_query.sql
+++ b/external_query.sql
@@ -32,11 +32,14 @@ SELECT state_name, MAX(core_data.batch_id) as max_bid
     WHERE batch.is_published = TRUE
     GROUP BY state_name;
 	
-/* States current: What's the latest published (non-preview) data for all states? */
+/* States current: What's the latest published (non-preview) data for all states?
+As written, this assumes that the latest date published for any state is the most recent for all states.
+*/
+WITH temp (latest_date) AS (SELECT MAX(data_date) FROM core_data)
 SELECT * FROM (
 	SELECT state_name, MAX(core_data.batch_id) as max_bid
-		FROM core_data INNER JOIN batch ON core_data.batch_id = batch.batch_id
-		WHERE batch.is_published = TRUE
+		FROM temp,core_data INNER JOIN batch ON core_data.batch_id = batch.batch_id
+		WHERE batch.is_published = TRUE AND core_data.data_date = temp.latest_date
 		GROUP BY state_name) AS latest_state_batches
 	INNER JOIN core_data ON (
 		core_data.batch_id = latest_state_batches.max_bid AND

--- a/init_test_data.sql
+++ b/init_test_data.sql
@@ -133,4 +133,17 @@ BEGIN
 		('NY', '2020-03-21 17:00:00', '2020-03-21 17:56:00', '2020-03-21', 210, 'JK', 'NY afternoon', last_batch_id);
 END $$;
 
+/* Revise data from the 20th. This will cause issues with naive queries that just get the most recent batchid */
+DO $$
+DECLARE last_batch_id BIGINT;
+BEGIN
+	INSERT INTO batch
+		(created_at, shift_lead, batch_note, is_published, is_revision, data_entry_type) VALUES
+		('2020-03-21 20:05:00', 'AS', '3/20 night', TRUE, TRUE, 'push')
+		RETURNING batch_id INTO last_batch_id;
+	INSERT INTO core_data 
+		(state_name, last_update_time, last_check_time, data_date, tests, checker, public_notes, batch_id) VALUES
+		('PA', '2020-03-21 17:00:00', '2020-03-21 17:55:00', '2020-03-20', 167, 'AS', 'PA afternoon', last_batch_id);
+END $$;
+
 SELECT * FROM core_data INNER JOIN batch ON core_data.batch_id = batch.batch_id;


### PR DESCRIPTION
After the change to the test data, the previous query would incorrectly return:
```
 state_name | max_bid | state_name |    last_update_time    |    last_check_time     | data_date  | tests | checker | double_checker | public_notes | private_notes | source_notes | batch_id | batch_id |       created_at       | published_at | shift_lead |      batch_note       | data_entry_type | is_published | is_revision 
------------+---------+------------+------------------------+------------------------+------------+-------+---------+----------------+--------------+---------------+--------------+----------+----------+------------------------+--------------+------------+-----------------------+-----------------+--------------+-------------
 NY         |       6 | NY         | 2020-03-21 14:00:00-04 | 2020-03-21 14:56:00-04 | 2020-03-21 |   200 | JK      |                | NY afternoon |               |              |        6 |        6 | 2020-03-21 15:00:00-04 |              | JK         | 3/21 afternoon, daily | daily_push      | t            | f
 PA         |       9 | PA         | 2020-03-21 17:00:00-04 | 2020-03-21 17:55:00-04 | 2020-03-20 |   167 | AS      |                | PA afternoon |               |              |        9 |        9 | 2020-03-21 20:05:00-04 |              | AS         | 3/20 night            | push            | t            | t
```

(note that it returns 3/20 data for PA instead of 3/21)

After the query change it returns:
```
 state_name | max_bid | state_name |    last_update_time    |    last_check_time     | data_date  | tests | checker | double_checker | public_notes | private_notes | source_notes | batch_id | batch_id |       created_at       | published_at | shift_lead |      batch_note       | data_entry_type | is_published | is_revision 
------------+---------+------------+------------------------+------------------------+------------+-------+---------+----------------+--------------+---------------+--------------+----------+----------+------------------------+--------------+------------+-----------------------+-----------------+--------------+-------------
 PA         |       6 | PA         | 2020-03-21 14:00:00-04 | 2020-03-21 14:55:00-04 | 2020-03-21 |   150 | JK      |                | PA afternoon |               |              |        6 |        6 | 2020-03-21 15:00:00-04 |              | JK         | 3/21 afternoon, daily | daily_push      | t            | f
 NY         |       6 | NY         | 2020-03-21 14:00:00-04 | 2020-03-21 14:56:00-04 | 2020-03-21 |   200 | JK      |                | NY afternoon |               |              |        6 |        6 | 2020-03-21 15:00:00-04 |              | JK         | 3/21 afternoon, daily | daily_push      | t            | f
(2 rows)
```